### PR TITLE
Remove unnecessary turnOnColorBulbs function and mark as deprecated

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,4 @@
 import { getDeviceIDs } from "./utils/getDeviceIDs";
-import { turnOnColorBulbs } from "./utils/turnOnColorBulbs";
 import { setColor } from "./utils/setColor";
 import { setBrightness } from "./utils/setBrightness";
 import { setColorTemperature } from "./utils/setColorTemperature";
@@ -48,7 +47,6 @@ import {
     console.info(`Setting color temperature to ${colorTemperature}`);
   }
 
-  await turnOnColorBulbs(deviceIDs);
   await setColor(deviceIDs, color || "255:255:255");
   await setBrightness(deviceIDs, brightness || 100);
   await setColorTemperature(deviceIDs, colorTemperature || 5000);

--- a/utils/turnOnColorBulbs.ts
+++ b/utils/turnOnColorBulbs.ts
@@ -1,6 +1,11 @@
 import { generateSign } from "./generateSign";
 import { Command, sendCommand } from "./sendCommand";
 
+/**
+ * @deprecated
+ * This function is deprecated and will be removed in the future because
+ * we learned that bulbs get turned on when receiving any other commands.
+ */
 export async function turnOnColorBulbs(deviceIDs: string[]): Promise<void> {
   const { token, sign, t, nonce } = generateSign();
   const command = {


### PR DESCRIPTION
Eliminate the turnOnColorBulbs function as it is redundant; it will be marked as deprecated for future removal.